### PR TITLE
[PATCH] iprdump

### DIFF
--- a/iprdump.c
+++ b/iprdump.c
@@ -103,6 +103,8 @@ static int read_dump(struct ipr_ioa *ioa)
 
 	sprintf(path, "/sys/class/scsi_host/%s/%s", ioa->host_name, "dump");
 	file = fopen(path, "r");
+	if (file == NULL)
+		return -1;
 	count = fread(&dump, 1 , sizeof(dump), file);
 	fclose(file);
 


### PR DESCRIPTION
iprutils: fix iprdump sigserv on non-existing dump file

Fixes: df133ac250e7d99d8e15e8a57cbc9b8244f1c069

Signed-off-by: Anatoly Pugachev <matorola@gmail.com>