### PR TITLE
configure.ac: add AC_USE_SYSTEM_EXTENSIONS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_INIT([iprutils], [2.4.19.1], [iprdd-devel@lists.sourceforge.net])
 
 AM_INIT_AUTOMAKE([1.9 foreign])
 AC_CONFIG_MACRO_DIR([build-aux])
+AC_USE_SYSTEM_EXTENSIONS
 
 # Checks for programs.
 AC_PROG_CC


### PR DESCRIPTION
uint and alphasort come from glibc, and with ancient versions thereof, they were guarded behind different sets of feature-test macros (see manpage for scandir() for example), which were not default back then.

```
In file included from iprdump.c:17:0:
iprlib.h:1866:2: error: unknown type name 'uint'
  uint supported_with_min_ucode_level;
  ^

iprlib.c: In function 'ipr_get_pci_slots':
iprlib.c:1999:48: error: 'alphasort' undeclared (first use in this function)
  num_slots = scandir(rootslot, &slotdir, NULL, alphasort);
                                                ^
```

Fix them by adding AC_USE_SYSTEM_EXTENSIONS in configure.ac

Fixes:
 - http://autobuild.buildroot.org/results/41fde4aa06f7c025bb05aa594716643b9010358f

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
Signed-off-by: Yann E. MORIN <yann.morin.1998@free.fr>