### PR TITLE
iprdbg will fall into an endless loop on stdin EOF

### DIFF
--- a/iprdbg.c
+++ b/iprdbg.c
@@ -226,16 +226,18 @@ static void ipr_fgets(char *buf, int size, FILE *stream)
 {
 	int i, ch = 0;
 
-	for (i = 0; ch != EOF && i < (size - 1); i++) {
+	for (i = 0; i < (size - 1); i++) {
 		ch = fgetc(stream);
-		if (ch == '\n')
+		if (ch == '\n' || ch == EOF)
 			break;
 
 		buf[i] = ch;
 	}
 
 	buf[i] = '\0';
-	strcat(buf, "\n");
+	if(ch != EOF || i > 0) {
+		strcat(buf, "\n");
+	}
 }
 
 static void dump_data(unsigned int adx, unsigned int *buf, int len)
@@ -827,6 +829,7 @@ int main(int argc, char *argv[])
 	while(1) {
 		printf("IPRDB(%X)> ", ioa->ccin);
 		ipr_fgets(cmd_line, 999, stdin);
+		if(!*cmd_line) break;
 		__logtofile("%s\n", SEPARATOR);
 		logtofile("%s", cmd_line);
 		exec_shell_cmd(ioa, cmd_line);


### PR DESCRIPTION
For example, when pressing ^D on an empty command prompt of **iprdbg(8)**, it will fall into a loop, flooding stdout (usually a terminal) and log file (`/var/log/iprdbg`):
```
# iprdbg

ATTENTION: This utility is for adapter developers only! Use at your own risk!

Use "quit" to exit the program.

IPRDB(572A)> Invalid command �. Use "help" for a list of valid commands
IPRDB(572A)> Invalid command �. Use "help" for a list of valid commands
IPRDB(572A)> Invalid command �. Use "help" for a list of valid commands
IPRDB(572A)> Invalid command �. Use "help" for a list of valid commands
IPRDB(572A)> Invalid command �. Use "help" for a list of valid commands
IPRDB(572A)> Invalid command �. Use "help" for a list of valid commands
...
```
This commit fixes 2 bugs:
* `ipr_fgets` incorrectly stores the EOF mark (`(int)-1`) into the output buffer (pointed by `buf`), resulted in that garble character in above output;
* The main loop in `main` didn't handle the stdin EOF condition, resulted an endless loop.